### PR TITLE
cli: add `-c` / `-i` for non-interactive use

### DIFF
--- a/doc/site/src/getting-started.rst
+++ b/doc/site/src/getting-started.rst
@@ -150,11 +150,11 @@ Once installed, the Devicetree Shell is available as the ``dtsh`` command:
 .. code-block:: none
 
    $ dtsh -h
-   usage: dtsh [-h] [-b DIR] [-u] [--preferences FILE] [--theme FILE] [DTS]
+   usage: dtsh [-h] [-b DIR] [-u] [--preferences FILE] [--theme FILE] [-c CMD] [-f FILE] [-i] [DTS]
 
    shell-like interface with Devicetree
 
-   optional arguments:
+   options:
      -h, --help            show this help message and exit
 
    open a DTS file:
@@ -166,6 +166,11 @@ Once installed, the Devicetree Shell is available as the ``dtsh`` command:
      -u, --user-files      initialize per-user configuration files and exit
      --preferences FILE    load additional preferences file
      --theme FILE          load additional styles file
+
+   session control:
+     -c CMD                execute CMD at startup (may be repeated)
+     -f FILE               execute batch commands from FILE at startup
+     -i, --interactive     enter interactive loop after batch commands
 
 We'll first confirm that the installation went well with a simple but typical usage,
 before tackling a few other scenarios.
@@ -270,6 +275,47 @@ Where:
   in Zephyr's `Devicetree Binding Syntax <Zephyr-Binding Syntax_>`_,
   even if not working with Zephyr
 - one of these directories shall contain a valid vendors file, e.g. ``dir1/vendor-prefixes.txt``
+
+
+.. _dtsh-usage-batch:
+
+Batch Mode
+==========
+
+For scripting and automation, DTSh can also be used non-interactively by passing:
+
+ - a series of commands to execute at startup: ``-c CMD1 -c CMD2``
+ - or a file containing such commands: ``-f FILE``
+
+The ``-i --interactive`` option then permits to enter the interactive loop after the batch commands have been executed.
+
+For example, to list the contents of the root of the devicetree and then change
+to another directory, before entering the interactive loop, you can use the
+following command:
+
+.. code-block:: none
+
+   $ dtsh -c "ls -l" -c "cd &i2c0" -i
+   dtsh (0.2.1): A Devicetree Shell
+   How to exit: q, or quit, or exit, or press Ctrl-D
+
+   > Name              Labels          Binding
+   ───────────────────────────────────────────────────────
+   chosen
+   aliases
+   soc
+   pin-controller    pinctrl         nordic,nrf-pinctrl
+   entropy_bt_hci    rng_hci         zephyr,bt-hci-entropy
+   sw-pwm            sw_pwm          nordic,nrf-sw-pwm
+   cpus
+   leds                              gpio-leds
+   pwmleds                           pwm-leds
+   buttons                           gpio-keys
+   connector         arduino_header  arduino-header-r3
+   analog-connector  arduino_adc     arduino,uno-adc
+
+   /soc/i2c@40003000
+   ❭
 
 
 .. _dtsh-configuration:

--- a/src/dtsh/io.py
+++ b/src/dtsh/io.py
@@ -12,7 +12,7 @@
 Unit tests and examples: tests/test_dtsh_io.py
 """
 
-from typing import Any, IO, Tuple, Optional, Sequence
+from typing import Any, IO, Tuple, Optional, List, Sequence
 
 import os
 import sys
@@ -321,3 +321,28 @@ class DTShInputFile(DTShInput):
         # A non-empty line should be a command line if not only spaces,
         # and not a comment.
         return not (line.isspace() or line.startswith("#"))
+
+
+class DTShInputCmds(DTShInput):
+    """Command-line argument source.
+
+    Returns commands as they are provided on the tool command line.
+    """
+
+    _cmds: List[str]
+
+    def __init__(self, cmds: List[str]) -> None:
+        """Initialize object.
+
+        Args:
+            cmds: List of commands to execute.
+        """
+        self._cmds = cmds
+
+    def readline(self, multi_prompt: Optional[Sequence[Any]] = None) -> str:
+        """Overrides DTShInput.readline()."""
+        if self._cmds:
+            line: str = self._cmds.pop(0)
+            return line
+
+        raise EOFError()

--- a/src/dtsh/rich/session.py
+++ b/src/dtsh/rich/session.py
@@ -23,7 +23,7 @@ from dtsh.shell import (
     DTShCommandError,
 )
 from dtsh.session import DTShSession
-from dtsh.io import DTShInput, DTShOutput, DTShRedirect, DTShVT, DTShInputFile
+from dtsh.io import DTShInput, DTShOutput, DTShRedirect, DTShVT, DTShInputFile, DTShInputCmds
 
 from dtsh.rich.io import (
     DTShRichVT,
@@ -49,7 +49,7 @@ class DTShRichSession(DTShSession):
         cls,
         dts_path: str,
         binding_dirs: Optional[List[str]],
-        batch: Union[str, Sequence[str]],
+        batch: Union[str, List[str]],
         interactive: bool,
     ) -> DTShSession:
         """Create batch session.
@@ -79,9 +79,11 @@ class DTShRichSession(DTShSession):
                 batch_is = DTShInputFile(batch)
             except DTShInputFile.Error as e:
                 raise DTShError(str(e)) from e
+        elif isinstance(batch, List):
+            # Batch commands from cli arguments.
+            batch_is = DTShInputCmds(batch)
         else:
-            # Batch commands.
-            raise NotImplementedError("create_batch(CMD)")
+            raise NotImplementedError(f"create_batch({repr(type(batch))})")
 
         dt = cls._create_dtmodel(dts_path, binding_dirs)
         vt = DTShBatchRichVT(batch_is, interactive)


### PR DESCRIPTION
Hello, thanks for the super nice tool and hope you accept PRs!

I have added `-c` and `-i` (as in the custom `sh` usage) to allow calling it non-interactively from scripts or command line.
As the tool is very nicely structured, I'm not sure I've done it TheRightWay :tm:  :slightly_smiling_face: so let me know any issues. 
Also, not sure where to look to add docs! :innocent: 
