### PR TITLE
session: trap SIGINT in interactive sessions like shells do

### DIFF
--- a/src/dtsh/session.py
+++ b/src/dtsh/session.py
@@ -138,6 +138,17 @@ class DTShSession:
             cmdline: Optional[str] = None
             try:
                 cmdline = self._vt.readline(self.mk_prompt())
+            except KeyboardInterrupt:
+                # If SIGINT is signaled (e.g. via 'CTRL-C' or 'kill -SIGINT')
+                # while reading keyboard inputs, Python will in turn raise a
+                # KeyboardInterrupt exception. Most shells respond to it by
+                # just echoing "^C" to the TTY and starting a new prompt, so
+                # this emulates the same behavior.
+                # Pagers usually trap and ignore SIGINT, but as a precaution
+                # we'll close it if one is still active.
+                self._vt.pager_exit()
+                self._vt.write("^C")
+                continue
             except EOFError:
                 # Exit DTSh on EOF.
                 self.close(interactive)
@@ -307,10 +318,6 @@ class DTShSession:
     def _preamble_hook(self) -> None:
         # Hook called when an interactive session starts.
 
-        # Closing with SIGINT when the pager is active breaks the TTY.
-        # As a work-around, we ignore SIGINT in interactive sessions.
-        signal.signal(signal.SIGINT, self._sig_handler)
-
         self._vt.clear()
         for line in self.mk_prologue():
             self._vt.write(line)
@@ -348,10 +355,3 @@ class DTShSession:
                 DTShBuiltinUname(),
             ],
         )
-
-    def _sig_handler(self, signum: int, frame: Optional[FrameType]) -> Any:
-        # closing() the session when the pager is active breaks the TTY.
-        # As a work-around, we ignore SIGINT.
-        del frame  # Unused.
-        if signum == signal.SIGINT:
-            pass


### PR DESCRIPTION
The current SIGINT handler in interactive sessions simply ignores it. This is not the behavior of most shells, which respond to SIGINT by restarting the prompt. This patch changes the behavior of DTSh to match that of shells.

Note: I'm unsure what the issue that is mentioned in the code with the pager is: Ctrl+C is properly trapped/handled by `less` in my Linux setup, and it is never passed to Python. Even trying to signal the process directly with `kill -INT $(pidof python3)` does not work while the pager is active. 
The call to `self._vt.pager_exit()` is thus just a precaution.  